### PR TITLE
Build against & use libpng 1.5+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,16 +176,16 @@ ZLIBLIB = -L$(ZLIBDIR)/lib -lz
 ### if, for whatever reason, you're unable to get the JasPer JPEG-2000 library
 ### to compile on your machine, *COMMENT OUT* the following lines
 ###
-JP2K    = -DDOJP2K
+#JP2K    = -DDOJP2K
 ###
 #JP2KDIR = ../../jasper
-JP2KDIR = /usr/local/lib
+#JP2KDIR = /usr/local/lib
 ###
 #JP2KINC = -I$(JP2KDIR)
-JP2KINC = -I/usr/local/include
+#JP2KINC = -I/usr/local/include
 ###
 #JP2KLIB = -L$(JP2KDIR) -ljasper
-JP2KLIB = $(JP2KDIR)/libjasper.a
+#JP2KLIB = $(JP2KDIR)/libjasper.a
 
 
 ###


### PR DESCRIPTION
Libpng 1.4 deprecated and libpng 1.5 finally abolished the direct access to the png_info structure that xv was using. There are a couple of other forks on GH that claim to build and work against modern libpng but some of the diffs looked a little shaky to me so I thought I'd start from scratch.

I did make some changes to the PNG comment handling, which appears to have been bugged in legacy xv (the tp pointer was not properly initialized in WritePNG if max_text was already > num_text, and the pointer was not properly advanced when adding non-keyword comments). Other than that the changes are solely what's required by the libpng changes, although it's tempting to start a wider cleanup effort. I also commented out the jasper (JPEG 2000 library) dependency in the Makefile, which lets this build on modern distributions where libjasper is not always easily available.

Built & tested against libpng 1.6.37 on Debian Bullseye (11.4), for both reading and writing.